### PR TITLE
Fix microbeHeatmap() not producting plot

### DIFF
--- a/R/curation_viz.R
+++ b/R/curation_viz.R
@@ -210,11 +210,11 @@ microbeHeatmap <- function(dat,
                                     tax.id.type = "taxname",
                                     tax.level = tax.level)
     rownames(cooc.mat) <- colnames(cooc.mat) <- n 
-    ComplexHeatmap::Heatmap(log10(cooc.mat + 0.1), 
+    print(ComplexHeatmap::Heatmap(log10(cooc.mat + 0.1), 
                             name = "log10 Co-occurence",
                             top_annotation = anno,
                             row_names_gp = gpar(fontsize = fontsize),
                             column_names_gp = gpar(fontsize = fontsize), 
-                            ...)
+                            ...))
     return(invisible(cooc.mat))
 }


### PR DESCRIPTION
`microbeHeatmap()` was not producing a plot due to the `return()` on the subsequent line after the `ComplexHeatmap::Heatmap()` call. Wrapping this call in `print()` appears to solve this issue.