### PR TITLE
Update URL to the NCBI ontology file

### DIFF
--- a/R/calcSemanticSimilarity.R
+++ b/R/calcSemanticSimilarity.R
@@ -81,9 +81,7 @@ getNcbiTaxonomyObo <- function() {
     onto <- .getResourceFromCache("ncbi.onto")
 
     if (is.null(onto)) {
-
-        url <- paste0("https://sandbox.zenodo.org/record/954943/files/",
-                      "ncbitaxon.rds?download=1")
+        url <- "https://github.com/waldronlab/ncbitaxon/raw/devel/ncbitaxon.rds"
         temp_file <- tempfile()
         message("Getting NCBI taxonomy ontology.")
         utils::download.file(url = url, destfile = temp_file)


### PR DESCRIPTION
Related to issue #15

@lgeistlinger, @cmirzayi,

I restored the file on this repo: https://github.com/waldronlab/ncbitaxon

If a Zenodo DOI is required I can upload the repo to Zenodo. I think the GH URL works just fine, though.

```
library(BugSigDBStats)
library(ontologyIndex)
ncbi<- getNcbiTaxonomyObo()
#> Using cached version from 2024-08-20 19:39:37
#> Retrieveing NCBI taxonomy ontology from cache.
ncbi
#> Ontology with 2594866 terms
#> 
#> format-version: 1.2
#> data-version: 2024-07-03
#> ontology: ncbitaxon
#> 
#> Properties:
#>  id: character
#>  name: character
#>  parents: list
#>  children: list
#>  ancestors: list
#>  obsolete: logical
#> Roots:
#>  NCBITaxon:taxonomic_rank - taxonomic rank
#>  NCBITaxon:1 - root
```