### PR TITLE
Updated pmid2pubyear function and fixed error from microbeHeatmap function

### DIFF
--- a/vignettes/BugSigDBStats.Rmd
+++ b/vignettes/BugSigDBStats.Rmd
@@ -49,10 +49,7 @@ Publication date of the curated papers:
 
 ```{r pubDate}
 pmids <- pmids[!is.na(pmids)]
-pubyear1 <- pmid2pubyear(pmids[1:361])
-pubyear2 <- pmid2pubyear(pmids[362:710])
-pubyear3 <- pmid2pubyear(pmids[711:length(pmids)])
-pubyear <- c(pubyear1, pubyear2, pubyear3)
+pubyear <- pmid2pubyear(pmids)
 head(cbind(pmids, pubyear))
 ```
 
@@ -276,8 +273,8 @@ sum(lengths(sigs) > 4)
 
 ```{r coocc, fig.width = 10, fig.height = 10}
 dat.feces <- subset(dat, `Body site` == "Feces")
-cooc.mat <- microbeHeatmap(dat.feces, tax.level = "genus")
-antag.mat <- microbeHeatmap(dat.feces, tax.level = "genus", antagonistic = TRUE)
+cooc.mat <- microbeHeatmap(dat.feces, tax.level = "genus", anno = "genus")
+antag.mat <- microbeHeatmap(dat.feces, tax.level = "genus", anno = "genus", antagonistic = TRUE)
 ```
 
 Get the top 20 genera most frequently reported as differentially abundant:
@@ -417,4 +414,3 @@ Create a dendrogram of Jaccard dissimilarities (1.0 has no overlap, 0.0 are iden
 jdist <- as.dist(1 - pair.jsim)
 plot(hclust(jdist))
 ```
-


### PR DESCRIPTION
- Updated `pmid2pubyear` function to automatically handle cases where the length of pmid is greater than 300, it splits the input pmid vector into smaller chunks, processes each chunk separately with a 2-second pause between requests, and then combine the results. This update removes the need for manual slicing and multiple function calls and generally simplifies the workflow to a single call.
- Updated `microbeHeatmap` call by setting `anno = "genus"` to match the taxonomic level `tax.level = "genus"`. This caused the annotation bar to align correctly with the heatmap's data, preventing dimension mismatches that previously caused an error.